### PR TITLE
Enable the additional parsers to support multiple import formats.

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -9,9 +9,16 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	kdotenv "github.com/knadh/koanf/parsers/dotenv"
+	kjson "github.com/knadh/koanf/parsers/json"
+	ktoml "github.com/knadh/koanf/parsers/toml"
+	kyaml "github.com/knadh/koanf/parsers/yaml"
 	kfile "github.com/knadh/koanf/providers/file"
 	"github.com/spf13/cobra"
 )
+
+type unmarshaller interface {
+	Unmarshal(b []byte) (map[string]interface{}, error)
+}
 
 var (
 	// For flags
@@ -19,13 +26,31 @@ var (
 	importType   string
 	importPath   string
 	importOWrite bool
+	format       string
 
 	// importCmd represents the import command
 	importCmd = &cobra.Command{
 		Use:   "import",
 		Short: "Import parameters from a file",
 		Run: func(cmd *cobra.Command, args []string) {
-			err := importParameters(file, importType, importPath, importOWrite)
+
+			// Define the map of string to parsers
+			parsers := map[string]unmarshaller{
+				"json":   kjson.Parser(),
+				"toml":   ktoml.Parser(),
+				"yaml":   kyaml.Parser(),
+				"dotenv": kdotenv.Parser(),
+			}
+
+			// Check the format arg is for a supported format
+			err := isValidFormat(format)
+			if err != nil {
+				utils.PrintErrorAndExit(err)
+			}
+
+			parser := parsers[format]
+
+			err = importParameters(file, importType, importPath, importOWrite, parser)
 			if err != nil {
 				utils.PrintErrorAndExit(err)
 			}
@@ -37,25 +62,32 @@ func init() {
 	rootCmd.AddCommand(importCmd)
 
 	importCmd.Flags().StringVarP(
-		&file, "file", "f", "", "path to the file",
+		&file, "file", "f", "", "path to the file to import",
 	)
 	importCmd.MarkFlagRequired("file")
+
 	importCmd.Flags().StringVarP(
-		&importType, "type", "t", "", "parameter type",
-	)
-	importCmd.Flags().StringVarP(
-		&importPath, "path", "p", "", "parameter path",
+		&importType, "type", "t", "", "aws parameter type to use when importing",
 	)
 	importCmd.MarkFlagRequired("type")
+
+	importCmd.Flags().StringVarP(
+		&importPath, "path", "p", "", "base path to import the parameters to",
+	)
+	importCmd.MarkFlagRequired("path")
+
 	importCmd.Flags().BoolVarP(
-		&importOWrite, "overwrite", "o", false, "overwrite parameters if they exist",
+		&importOWrite, "overwrite", "o", false, "overwrite parameters if they exist, i.e. update them",
+	)
+
+	importCmd.Flags().StringVarP(
+		&format, "format", "", "dotenv", "file format. [json toml yaml dotenv]",
 	)
 }
 
-func importParameters(file string, typ string, path string, overwrite bool) error {
+func importParameters(file string, typ string, path string, overwrite bool, parser unmarshaller) error {
 
 	provider := kfile.Provider(file)
-	parser := kdotenv.Parser()
 
 	// Get the raw bytest from the provider
 	b, err := provider.ReadBytes()
@@ -102,4 +134,18 @@ func importParameters(file string, typ string, path string, overwrite bool) erro
 	fmt.Printf("Successfully imported %d / %d parameters", count, len(mp))
 
 	return nil
+}
+
+func isValidFormat(format string) error {
+	// Supported formats
+	supported := []string{"json", "toml", "yaml", "dotenv"}
+
+	for _, v := range supported {
+		if v == format {
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"Unsupported input file format `%s`. Supported formats are: %v", format, supported,
+	)
 }

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,7 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pelletier/go-toml v1.7.0 h1:7utD74fnzVc/cpcyy8sjrlFr5vYpypUixARcHIMIGuI=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
The underlying `koanf` library supports json, toml and yaml in addition
to dotenv. The goss import command now supports these other formats
through the use of the `--format flag`.

```bash
goss import -f test.toml -t SecureString -p /dev --format toml
```